### PR TITLE
Fix content width on smaller devices

### DIFF
--- a/assets/less/content.less
+++ b/assets/less/content.less
@@ -112,6 +112,7 @@
     }
     a{
         font-weight: 600;
+        word-wrap: break-word;
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug that is present on smaller devices in the content area, where if there is a long word or a link, it will make the page to be horizontally scrollable. By applying this PR, long words will be broken in new line.