### PR TITLE
Add support for excerpts on pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -44,6 +44,11 @@ function keitaro_theme_setup() {
 	 * provide it for us.
 	 */
 	add_theme_support( 'title-tag' );
+	
+	/*
+	 * Add support for excerpts on Pages
+	 */
+	add_post_type_support( 'page', 'excerpt' );
 
 	/*
 	 * Enable support for Post Thumbnails on posts and pages.


### PR DESCRIPTION
This PR extends the page content type to support excerpts in the same way they are available for posts.