### PR TITLE
Linkedin Partner ID

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -43,6 +43,7 @@
 keitaro_go_to_top_link( __( 'Go to Top', 'keitaro' ) );
 
 get_template_part( SNIPPETS_DIR . '/google-analytics' );
+get_template_part( SNIPPETS_DIR . '/linkedin-partner' );
 
 ?>
 </body>

--- a/template-snippets/class-keitaro-theme-settings.php
+++ b/template-snippets/class-keitaro-theme-settings.php
@@ -110,6 +110,14 @@ class Keitaro_Theme_Settings {
 		);
 
 		add_settings_field(
+			'li_partner_id',
+			__( 'LinkedIn Partner ID', 'keitaro' ),
+			array( $this, 'li_partner_id_callback' ),
+			'keitaro-setting-admin',
+			'setting_section_id'
+		);
+
+		add_settings_field(
 			'metricool_verification_hash_id',
 			__( 'Metricool Hash ID', 'keitaro' ),
 			array( $this, 'metricool_verification_hash_id_callback' ),
@@ -136,6 +144,10 @@ class Keitaro_Theme_Settings {
 
 		if ( isset( $input['fb_pixel_id'] ) ) {
 			$new_input['fb_pixel_id'] = sanitize_text_field( $input['fb_pixel_id'] );
+		}
+
+		if ( isset( $input['li_partner_id'] ) ) {
+			$new_input['li_partner_id'] = sanitize_text_field( $input['li_partner_id'] );
 		}
 
 		if ( isset( $input['metricool_verification_hash_id'] ) ) {
@@ -183,6 +195,15 @@ class Keitaro_Theme_Settings {
 		printf(
 			'<input type="text" id="fb_pixel_id" name="keitaro_settings[fb_pixel_id]" value="%s" />',
 			isset( $this->options['fb_pixel_id'] ) ? esc_attr( $this->options['fb_pixel_id'] ) : '');
+		}
+
+	/**
+	 * Get the settings option array and print one of its values
+	 */
+	public function li_partner_id_callback() {
+		printf(
+			'<input type="text" id="li_partner_id" name="keitaro_settings[li_partner_id]" value="%s" />',
+			isset( $this->options['li_partner_id'] ) ? esc_attr( $this->options['li_partner_id'] ) : '');
 		}
 
 	/**

--- a/template-snippets/linkedin-partner.php
+++ b/template-snippets/linkedin-partner.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Template snippet for LinkedIn Patner ID
+ *
+ * @link https://github.com/keitaroinc/keitaro-theme
+ *
+ * @package WordPress
+ * @subpackage Keitaro
+ */
+
+$linkedin_partner_id = get_option('keitaro_settings')['li_partner_id'] ?? false;
+
+if ($linkedin_partner_id) :
+
+?>
+
+	<script type="text/javascript">
+		_linkedin_partner_id = <?php echo esc_js($linkedin_partner_id); ?>;
+		window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+		window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+	</script>
+	<script type="text/javascript">
+		(function(l) {
+			if (!l) {
+				window.lintrk = function(a, b) {
+					window.lintrk.q.push([a, b])
+				};
+				window.lintrk.q = []
+			}
+			var s = document.getElementsByTagName("script")[0];
+			var b = document.createElement("script");
+			b.type = "text/javascript";
+			b.async = true;
+			b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+			s.parentNode.insertBefore(b, s);
+		})(window.lintrk);
+	</script>
+	<noscript>
+		<img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=<?php echo esc_js($linkedin_partner_id); ?>&fmt=gif" />
+	</noscript>
+<?php
+
+endif;


### PR DESCRIPTION
This PR adds support for managing LinkedIn Partner IDs directly from the Keitaro Settings page.